### PR TITLE
chore(ci): fix deprecated GitHub Actions syntax

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Initialize mandatory git config
         run: |
           git config user.name "GitHub Actions"
@@ -30,7 +30,7 @@ jobs:
         run: |
           git add VERSION 
           git commit --message "Prepare release ${{ github.event.inputs.releaseVersion }}"
-          echo "::set-output name=commit::$(git rev-parse HEAD)"
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Push the branch
         run: git push origin release/${{ github.event.inputs.releaseVersion }}
       - name: Create pull request into master

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,7 +13,7 @@ jobs:
       release_version: ${{ steps.outputs.outputs.release_version }}
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Initialize mandatory git config
         run: |
           git config user.name "GitHub Actions"


### PR DESCRIPTION
Automated update for CI deprecations:

- [`::set-output` / `::save-state`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) → environment files
- [`actions/checkout` v4 and older on Node 20 runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) → `actions/checkout@v5`

Please review: complex `set-output` values (multiline, special chars) may need a manual tweak.
