### PR TITLE
Feature/multipart form content type

### DIFF
--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/cookiejar"
+	"net/textproto"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -433,12 +434,25 @@ func (e Executor) getRequest(ctx context.Context, workdir string) (*http.Request
 			// Considering file will be prefixed by @ (since you could also post regular data in the body)
 			if strings.HasPrefix(value, "@") {
 				// todo: how can we be sure the @ is not the value we wanted to use ?
-				if _, err := os.Stat(value[1:]); !os.IsNotExist(err) {
-					part, err := writer.CreateFormFile(key, filepath.Base(value[1:]))
+				filePath := value[1:]
+				contentType := "application/octet-stream"
+				// Mirrors curl's `-F field=@path;type=content/type` syntax, since
+				// multipart.Writer.CreateFormFile hardcodes application/octet-stream
+				// and can't be overridden, which some servers reject via Content-Type
+				// allow-lists.
+				if idx := strings.LastIndex(filePath, ";type="); idx != -1 {
+					contentType = filePath[idx+len(";type="):]
+					filePath = filePath[:idx]
+				}
+				if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+					header := textproto.MIMEHeader{}
+					header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, escapeQuotes(key), escapeQuotes(filepath.Base(filePath))))
+					header.Set("Content-Type", contentType)
+					part, err := writer.CreatePart(header)
 					if err != nil {
 						return nil, err
 					}
-					if err := writeFile(part, value[1:]); err != nil {
+					if err := writeFile(part, filePath); err != nil {
 						return nil, err
 					}
 					continue
@@ -479,6 +493,14 @@ func (e Executor) getRequest(ctx context.Context, workdir string) (*http.Request
 		req.Header.Set("Content-Type", writer.FormDataContentType())
 	}
 	return req, err
+}
+
+// quoteEscaper mirrors the unexported escaper mime/multipart uses internally
+// for CreateFormFile, since CreatePart requires callers to escape headers themselves.
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+func escapeQuotes(s string) string {
+	return quoteEscaper.Replace(s)
 }
 
 // writeFile writes the content of the file to an io.Writer

--- a/executors/http/http.go
+++ b/executors/http/http.go
@@ -427,39 +427,28 @@ func (e Executor) getRequest(ctx context.Context, workdir string) (*http.Request
 		}
 		writer = multipart.NewWriter(body)
 		for key, v := range form {
-			value, ok := v.(string)
-			if !ok {
-				return nil, fmt.Errorf("'multipart_form' should be a map with values as strings")
-			}
-			// Considering file will be prefixed by @ (since you could also post regular data in the body)
-			if strings.HasPrefix(value, "@") {
-				// todo: how can we be sure the @ is not the value we wanted to use ?
-				filePath := value[1:]
-				contentType := "application/octet-stream"
-				// Mirrors curl's `-F field=@path;type=content/type` syntax, since
-				// multipart.Writer.CreateFormFile hardcodes application/octet-stream
-				// and can't be overridden, which some servers reject via Content-Type
-				// allow-lists.
-				if idx := strings.LastIndex(filePath, ";type="); idx != -1 {
-					contentType = filePath[idx+len(";type="):]
-					filePath = filePath[:idx]
-				}
-				if _, err := os.Stat(filePath); !os.IsNotExist(err) {
-					header := textproto.MIMEHeader{}
-					header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, escapeQuotes(key), escapeQuotes(filepath.Base(filePath))))
-					header.Set("Content-Type", contentType)
-					part, err := writer.CreatePart(header)
-					if err != nil {
-						return nil, err
+			// A key's value is either a single string, or a list of strings to
+			// send the same field name multiple times (e.g. a repeated "files"
+			// part for a multi-file upload).
+			var values []string
+			switch t := v.(type) {
+			case string:
+				values = []string{t}
+			case []interface{}:
+				for _, item := range t {
+					value, ok := item.(string)
+					if !ok {
+						return nil, fmt.Errorf("'multipart_form' list values must be strings, got %T", item)
 					}
-					if err := writeFile(part, filePath); err != nil {
-						return nil, err
-					}
-					continue
+					values = append(values, value)
 				}
+			default:
+				return nil, fmt.Errorf("'multipart_form' values must be a string or a list of strings, got %T", v)
 			}
-			if err := writer.WriteField(key, value); err != nil {
-				return nil, err
+			for _, value := range values {
+				if err := writeMultipartField(writer, key, value); err != nil {
+					return nil, err
+				}
 			}
 		}
 		if err := writer.Close(); err != nil {
@@ -501,6 +490,36 @@ var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
 func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)
+}
+
+// writeMultipartField writes a single multipart_form value under key. A value
+// prefixed with "@" is treated as a file to attach (since you could also post
+// regular data in the body); otherwise it's written as a plain form field.
+func writeMultipartField(writer *multipart.Writer, key, value string) error {
+	// todo: how can we be sure the @ is not the value we wanted to use ?
+	if strings.HasPrefix(value, "@") {
+		filePath := value[1:]
+		contentType := "application/octet-stream"
+		// Mirrors curl's `-F field=@path;type=content/type` syntax, since
+		// multipart.Writer.CreateFormFile hardcodes application/octet-stream
+		// and can't be overridden, which some servers reject via Content-Type
+		// allow-lists.
+		if idx := strings.LastIndex(filePath, ";type="); idx != -1 {
+			contentType = filePath[idx+len(";type="):]
+			filePath = filePath[:idx]
+		}
+		if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+			header := textproto.MIMEHeader{}
+			header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, escapeQuotes(key), escapeQuotes(filepath.Base(filePath))))
+			header.Set("Content-Type", contentType)
+			part, err := writer.CreatePart(header)
+			if err != nil {
+				return err
+			}
+			return writeFile(part, filePath)
+		}
+	}
+	return writer.WriteField(key, value)
 }
 
 // writeFile writes the content of the file to an io.Writer

--- a/executors/http/http_test.go
+++ b/executors/http/http_test.go
@@ -227,3 +227,55 @@ func TestMultipartForm_FileContentType(t *testing.T) {
 		})
 	}
 }
+
+func TestMultipartForm_RepeatedFileField(t *testing.T) {
+	fileA, err := os.CreateTemp(t.TempDir(), "upload-a-*.txt")
+	require.NoError(t, err)
+	_, err = fileA.WriteString("content a")
+	require.NoError(t, err)
+	require.NoError(t, fileA.Close())
+
+	fileB, err := os.CreateTemp(t.TempDir(), "upload-b-*.md")
+	require.NoError(t, err)
+	_, err = fileB.WriteString("content b")
+	require.NoError(t, err)
+	require.NoError(t, fileB.Close())
+
+	e := &Executor{
+		MultipartForm: map[string]interface{}{
+			"files": []interface{}{
+				"@" + fileA.Name() + ";type=text/plain",
+				"@" + fileB.Name() + ";type=text/markdown",
+			},
+		},
+	}
+	req, err := e.getRequest(context.Background(), "")
+	require.NoError(t, err)
+	defer req.Body.Close()
+
+	_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	require.NoError(t, err)
+
+	mr := multipart.NewReader(req.Body, params["boundary"])
+
+	part1, err := mr.NextPart()
+	require.NoError(t, err)
+	require.Equal(t, "files", part1.FormName())
+	require.Equal(t, filepath.Base(fileA.Name()), part1.FileName())
+	require.Equal(t, "text/plain", part1.Header.Get("Content-Type"))
+	body1, err := io.ReadAll(part1)
+	require.NoError(t, err)
+	require.Equal(t, "content a", string(body1))
+
+	part2, err := mr.NextPart()
+	require.NoError(t, err)
+	require.Equal(t, "files", part2.FormName())
+	require.Equal(t, filepath.Base(fileB.Name()), part2.FileName())
+	require.Equal(t, "text/markdown", part2.Header.Get("Content-Type"))
+	body2, err := io.ReadAll(part2)
+	require.NoError(t, err)
+	require.Equal(t, "content b", string(body2))
+
+	_, err = mr.NextPart()
+	require.ErrorIs(t, err, io.EOF)
+}

--- a/executors/http/http_test.go
+++ b/executors/http/http_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 
@@ -176,4 +179,51 @@ func TestCookieRedirect(t *testing.T) {
 	require.Equal(t, result.StatusCode, http.StatusOK)
 
 	require.Equal(t, int32(1), callCount.Load())
+}
+
+func TestMultipartForm_FileContentType(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "upload-*.pdf")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString("fixture content")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	cases := []struct {
+		name        string
+		value       string
+		wantContent string
+	}{
+		{
+			name:        "defaults to octet-stream when no type is given",
+			value:       "@" + tmpFile.Name(),
+			wantContent: "application/octet-stream",
+		},
+		{
+			name:        "honors an explicit ;type= override",
+			value:       "@" + tmpFile.Name() + ";type=application/pdf",
+			wantContent: "application/pdf",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &Executor{
+				MultipartForm: map[string]interface{}{
+					"files": tc.value,
+				},
+			}
+			req, err := e.getRequest(context.Background(), "")
+			require.NoError(t, err)
+			defer req.Body.Close()
+
+			_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+			require.NoError(t, err)
+
+			mr := multipart.NewReader(req.Body, params["boundary"])
+			part, err := mr.NextPart()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantContent, part.Header.Get("Content-Type"))
+			require.Equal(t, filepath.Base(tmpFile.Name()), part.FileName())
+		})
+	}
 }


### PR DESCRIPTION
  Adds two related improvements to multipart form handling in the HTTP executor:                                                                                                                           
  - Content-Type override: file uploads via @path can now specify @path;type=content/type to set the part's Content-Type, instead of always getting the hardcoded application/octet-stream.   
  - Repeated fields: multipart_form values can now be a list of strings for multi-file uploads.    